### PR TITLE
Embed length header in KFE codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ python kfe_codec.py decode kfe/output.mp4 bin/restored.bin
 ```
 
 The codec uses frames of size 3840×2160 (RGB), so each frame stores exactly
-24,883,200 bytes of data. During encoding the last frame is zero padded as
-needed and the padding is removed during decoding.
+24,883,200 bytes of data. The original file size is written to the first frame
+so any padding added to the final frame can be removed during decoding.


### PR DESCRIPTION
## Summary
- store the original input length in the first frame during encode
- read that length during decode and truncate data accordingly
- remove previous padding strip logic
- update README about header frame

## Testing
- `python -m py_compile kfe_codec.py`

------
https://chatgpt.com/codex/tasks/task_e_683a3a7dec8c8325935efbf335826f8a