### PR TITLE
Add pytest roundtrip test

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+
+import pytest
+
+from kfe_codec import encode, decode
+
+
+def test_encode_decode_roundtrip(tmp_path):
+    data = os.urandom(1024)
+    input_file = tmp_path / 'input.bin'
+    video_file = tmp_path / 'output.mp4'
+    restored_file = tmp_path / 'restored.bin'
+
+    with open(input_file, 'wb') as f:
+        f.write(data)
+
+    encode(str(input_file), str(video_file))
+    decode(str(video_file), str(restored_file))
+
+    with open(restored_file, 'rb') as f:
+        restored = f.read()
+
+    assert restored == data


### PR DESCRIPTION
## Summary
- add a pytest test that verifies encoding/decoding roundtrip

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kfe_codec')*

------
https://chatgpt.com/codex/tasks/task_e_683ab992f73c8325835d37e94440568e