### PR TITLE
Add dependency file and reference in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ kfe_codec.py  # codec implementation
 ## Requirements
 
 - Python 3.8+
-- NumPy
-- OpenCV (`opencv-python`)
+- The Python packages listed in `requirements.txt`
 
-Install the Python dependencies with:
+Install the dependencies with:
 
 ```
-pip install numpy opencv-python
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+opencv-python

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,3 +1,10 @@
+"""Tests for the KFE codec.
+
+Dependencies for these tests are listed in ``requirements.txt``. Install them with::
+
+    pip install -r requirements.txt
+"""
+
 import os
 import tempfile
 


### PR DESCRIPTION
## Summary
- add `requirements.txt`
- update README to use `requirements.txt`
- mention `requirements.txt` in test file header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kfe_codec')*

------
https://chatgpt.com/codex/tasks/task_e_683abfa4a9c083258b1294ab8b9de547