### PR TITLE
Switch to FFV1 lossless codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,23 @@ pip install -r requirements.txt
 
 ## Usage
 
-Encode a binary file to a video:
+Encode a binary file to a video (the video is encoded using the lossless FFV1
+codec):
 
 ```
-python kfe_codec.py encode bin/input.bin kfe/output.mp4
+python kfe_codec.py encode bin/input.bin kfe/output.mkv
 ```
 
 Decode a video back to a binary file:
 
 ```
-python kfe_codec.py decode kfe/output.mp4 bin/restored.bin
+python kfe_codec.py decode kfe/output.mkv bin/restored.bin
 ```
 
 The codec uses frames of size 3840×2160 (RGB), so each frame stores exactly
 24,883,200 bytes of data. The original file size is written to the first frame
 so any padding added to the final frame can be removed during decoding.
+
+The implementation uses the **FFV1** codec for writing videos. FFV1 is a
+lossless codec, ensuring that every byte of the original file is preserved in
+the encoded video without degradation.

--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -20,7 +20,10 @@ def encode(input_path: str, output_path: str) -> None:
     header = len(data).to_bytes(8, 'big') + b'\x00' * (BYTES_PER_FRAME - 8)
     header_frame = np.frombuffer(header, dtype=np.uint8).reshape((FRAME_HEIGHT, FRAME_WIDTH, CHANNELS))
 
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    # Use a lossless codec so encoded videos preserve the exact binary data.
+    # FFV1 is a widely supported lossless codec available in FFMPEG builds
+    # shipped with OpenCV.
+    fourcc = cv2.VideoWriter_fourcc(*'FFV1')
     writer = cv2.VideoWriter(output_path, fourcc, 60, (FRAME_WIDTH, FRAME_HEIGHT))
 
     writer.write(header_frame)

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -16,7 +16,7 @@ from kfe_codec import encode, decode
 def test_encode_decode_roundtrip(tmp_path):
     data = os.urandom(1024)
     input_file = tmp_path / 'input.bin'
-    video_file = tmp_path / 'output.mp4'
+    video_file = tmp_path / 'output.mkv'
     restored_file = tmp_path / 'restored.bin'
 
     with open(input_file, 'wb') as f:


### PR DESCRIPTION
## Summary
- switch the encoder to FFV1 so video encoding is lossless
- document the new codec and adjust examples
- update tests to use MKV containers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683ac18e7b6c8325a6e4229a07397820