### PR TITLE
Add mp4 temp MKV encoding

### DIFF
--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -13,11 +13,12 @@ def encode(input_path: str, output_path: str) -> None:
 
     """Encode a binary file into a KFE video.
 
-    The FFV1 codec is used for lossless encoding, but some containers like MP4
-    do not support it. To work around this limitation the video is first written
-    to an ``.mkv`` file and then renamed to the requested output path. FFmpeg
-    is able to detect the container from the file header, so decoding works even
-    if the extension does not match the actual container.
+    The FFV1 codec is used for lossless encoding, but the MP4 container does not
+    support that codec. When the output path ends with ``.mp4`` the video is
+    first written to a temporary ``.mkv`` file and then renamed to the desired
+    MP4 path once ``writer.release()`` completes. FFmpeg detects the container
+    from the file header, so decoding works even if the extension does not match
+    the actual container.
     """
 
     out_dir = os.path.dirname(output_path)
@@ -25,7 +26,8 @@ def encode(input_path: str, output_path: str) -> None:
         os.makedirs(out_dir, exist_ok=True)
 
     temp_output = output_path
-    use_temp = not output_path.lower().endswith(".mkv")
+    # MP4 containers cannot store FFV1 streams, so write to an MKV file first
+    use_temp = output_path.lower().endswith(".mp4")
     if use_temp:
         temp_output = output_path + ".tmp.mkv"
 

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -17,13 +17,15 @@ from kfe_codec import encode, decode, BYTES_PER_FRAME
 def test_encode_decode_roundtrip(tmp_path):
     data = os.urandom(1024)
     input_file = tmp_path / 'input.bin'
-    video_file = tmp_path / 'output.mkv'
+    video_file = tmp_path / 'output.mp4'
+    temp_mkv = tmp_path / 'output.mp4.tmp.mkv'
     restored_file = tmp_path / 'restored.bin'
 
     with open(input_file, 'wb') as f:
         f.write(data)
 
     encode(str(input_file), str(video_file))
+    assert not temp_mkv.exists()
     decode(str(video_file), str(restored_file))
 
     with open(restored_file, 'rb') as f:


### PR DESCRIPTION
## Summary
- write mp4 outputs through a temporary mkv then rename
- update roundtrip test to use mp4 and confirm temp mkv cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af09ad1648325ac55c448b6269a98