### PR TITLE
Remove MP4 rename logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ codec):
 python kfe_codec.py encode bin/input.bin kfe/output.mkv
 ```
 
-When the output path ends in `.mp4` the encoder first writes a temporary MKV
-file and then renames it to the requested MP4 filename. This allows the lossless
-FFV1 stream to be stored inside an MP4 container.
+Currently the encoder only supports writing MKV files. Use the `.mkv`
+extension for the output path when encoding.
 
 Decode a video back to a binary file:
 

--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -13,24 +13,13 @@ def encode(input_path: str, output_path: str) -> None:
 
     """Encode a binary file into a KFE video.
 
-    The FFV1 codec is used for lossless encoding, but the MP4 container does not
-    support that codec. When the output path ends with ``.mp4`` the video is
-    first written to a temporary ``.mkv`` file and then renamed to the desired
-    MP4 path once ``writer.release()`` completes. FFmpeg detects the container
-    from the file header, so decoding works even if the extension does not match
-    the actual container.
+    The output is always an MKV container encoded with the lossless FFV1 codec.
+    MP4 output is not supported.
     """
 
     out_dir = os.path.dirname(output_path)
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
-
-    temp_output = output_path
-    # MP4 containers cannot store FFV1 streams, so write to an MKV file first
-    use_temp = output_path.lower().endswith(".mp4")
-    if use_temp:
-        temp_output = output_path + ".tmp.mkv"
-
 
     with open(input_path, "rb") as f:
         data = f.read()
@@ -47,7 +36,7 @@ def encode(input_path: str, output_path: str) -> None:
     fourcc = cv2.VideoWriter_fourcc(*"FFV1")
     writer = cv2.VideoWriter(
 
-        temp_output, fourcc, 60, (FRAME_WIDTH, FRAME_HEIGHT)
+        output_path, fourcc, 60, (FRAME_WIDTH, FRAME_HEIGHT)
 
     )
     if not writer.isOpened():
@@ -64,8 +53,6 @@ def encode(input_path: str, output_path: str) -> None:
         )
         writer.write(frame)
     writer.release()
-    if use_temp:
-        os.replace(temp_output, output_path)
 
 
 def decode(input_path: str, output_path: str) -> None:

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -17,15 +17,13 @@ from kfe_codec import encode, decode, BYTES_PER_FRAME
 def test_encode_decode_roundtrip(tmp_path):
     data = os.urandom(1024)
     input_file = tmp_path / 'input.bin'
-    video_file = tmp_path / 'output.mp4'
-    temp_mkv = tmp_path / 'output.mp4.tmp.mkv'
+    video_file = tmp_path / 'output.mkv'
     restored_file = tmp_path / 'restored.bin'
 
     with open(input_file, 'wb') as f:
         f.write(data)
 
     encode(str(input_file), str(video_file))
-    assert not temp_mkv.exists()
     decode(str(video_file), str(restored_file))
 
     with open(restored_file, 'rb') as f:
@@ -36,7 +34,7 @@ def test_encode_decode_roundtrip(tmp_path):
 
 def test_encode_decode_empty_file(tmp_path):
     input_file = tmp_path / 'empty.bin'
-    video_file = tmp_path / 'empty.mp4'
+    video_file = tmp_path / 'empty.mkv'
     restored_file = tmp_path / 'restored.bin'
 
     open(input_file, 'wb').close()
@@ -53,7 +51,7 @@ def test_encode_decode_empty_file(tmp_path):
 def test_encode_decode_large_file(tmp_path):
     data = os.urandom(BYTES_PER_FRAME + 500)
     input_file = tmp_path / 'large.bin'
-    video_file = tmp_path / 'large.mp4'
+    video_file = tmp_path / 'large.mkv'
     restored_file = tmp_path / 'restored.bin'
 
     with open(input_file, 'wb') as f:
@@ -70,13 +68,13 @@ def test_encode_decode_large_file(tmp_path):
 
 def test_encode_missing_input(tmp_path):
     missing_file = tmp_path / 'nope.bin'
-    video_file = tmp_path / 'out.mp4'
+    video_file = tmp_path / 'out.mkv'
     with pytest.raises(FileNotFoundError):
         encode(str(missing_file), str(video_file))
 
 
 def test_decode_missing_input(tmp_path):
-    missing_video = tmp_path / 'nope.mp4'
+    missing_video = tmp_path / 'nope.mkv'
     output_file = tmp_path / 'out.bin'
     with pytest.raises(IOError):
         decode(str(missing_video), str(output_file))


### PR DESCRIPTION
## Summary
- document that only MKV output is supported
- drop MP4 rename logic from `encode`
- update tests for MKV only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683afa9c675c832590da4bc0814e9a7c