### PR TITLE
Check for truncated video on decode

### DIFF
--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -85,6 +85,11 @@ def decode(input_path: str, output_path: str) -> None:
             written += bytes_to_write
     cap.release()
 
+    if written != original_size:
+        raise IOError(
+            "Video ended before all data could be read; file may be truncated or corrupted"
+        )
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="KFE Codec Prototype")

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -78,3 +78,24 @@ def test_decode_missing_input(tmp_path):
     output_file = tmp_path / 'out.bin'
     with pytest.raises(IOError):
         decode(str(missing_video), str(output_file))
+
+
+def test_decode_truncated_video(tmp_path):
+    data = os.urandom(100)
+    input_file = tmp_path / 'input.bin'
+    full_video = tmp_path / 'full.mkv'
+    truncated_video = tmp_path / 'truncated.mkv'
+    output_file = tmp_path / 'out.bin'
+
+    with open(input_file, 'wb') as f:
+        f.write(data)
+
+    encode(str(input_file), str(full_video))
+
+    # Create a truncated copy of the video file
+    with open(full_video, 'rb') as src, open(truncated_video, 'wb') as dst:
+        content = src.read()
+        dst.write(content[: len(content) // 2])
+
+    with pytest.raises(IOError):
+        decode(str(truncated_video), str(output_file))


### PR DESCRIPTION
## Summary
- validate the number of bytes written during decoding
- raise an error if the video ended early
- add a regression test with a truncated file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683afc26349c832594ef9728211323fc