### PR TITLE
Add streaming checksum and container options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,20 @@ pip install -r requirements.txt
 In a Codex workspace this setup is automated by running `codex/setup.sh`,
 which installs the required Python packages.
 
+Alternatively the project can be installed as a package using ``pip``:
+
+```
+pip install .
+```
+
 ## Usage
 
-Encode a binary file to a video (the video is encoded using the lossless FFV1
-codec):
+Encode a binary file to a video. By default the output is an MKV container
+encoded with FFV1. Use ``--container mp4`` to produce an MP4 file:
 
 ```
-python kfe_codec.py encode bin/input.bin kfe/output.mkv
+python kfe_codec.py encode bin/input.bin kfe/output --container mkv
 ```
-
-Currently the encoder only supports writing MKV files. Use the `.mkv`
-extension for the output path when encoding.
 
 Decode a video back to a binary file:
 
@@ -46,7 +49,8 @@ python kfe_codec.py decode kfe/output.mkv bin/restored.bin
 
 The codec uses frames of size 3840×2160 (RGB), so each frame stores exactly
 24,883,200 bytes of data. The original file size is written to the first frame
-so any padding added to the final frame can be removed during decoding.
+along with a SHA-256 checksum so any padding added to the final frame can be
+removed during decoding and the output validated.
 
 The implementation uses the **FFV1** codec for writing videos. FFV1 is a
 lossless codec, ensuring that every byte of the original file is preserved in

--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -1,5 +1,8 @@
 import argparse
 import os
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import cv2
 
@@ -9,55 +12,108 @@ CHANNELS = 3
 BYTES_PER_FRAME = FRAME_WIDTH * FRAME_HEIGHT * CHANNELS
 
 
-def encode(input_path: str, output_path: str) -> None:
+def _chunk_to_frame(chunk: bytes) -> np.ndarray:
+    """Convert a BYTES_PER_FRAME sized chunk to a frame array."""
+    return np.frombuffer(chunk, dtype=np.uint8).reshape(
+        (FRAME_HEIGHT, FRAME_WIDTH, CHANNELS)
+    )
+
+
+def _frame_to_bytes(frame: np.ndarray) -> bytes:
+    """Convert a frame array back to raw bytes."""
+    return frame.tobytes()
+
+
+def encode(
+    input_path: str,
+    output_path: str,
+    *,
+    container: str = "mkv",
+    workers: int = 1,
+) -> None:
 
     """Encode a binary file into a KFE video.
 
-    The output is always an MKV container encoded with the lossless FFV1 codec.
-    MP4 output is not supported.
+    Parameters
+    ----------
+    input_path:
+        Path to the binary file to encode.
+    output_path:
+        Path to the output video file. The extension is optional and is
+        determined from ``container`` if missing.
+    container:
+        Either ``"mkv"`` (lossless FFV1) or ``"mp4"`` (MPEG-4). Defaults to
+        ``"mkv"``.
+    workers:
+        Number of worker threads used when converting chunks to frames. The
+        writer itself remains sequential.
     """
 
     out_dir = os.path.dirname(output_path)
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
 
+    if not output_path.endswith(f".{container}"):
+        output_path += f".{container}"
+
     file_size = os.path.getsize(input_path)
 
-    # First frame stores the original file size so decoding can trim padding
-    header = file_size.to_bytes(8, "big") + b"\x00" * (BYTES_PER_FRAME - 8)
-    header_frame = np.frombuffer(header, dtype=np.uint8).reshape(
-        (FRAME_HEIGHT, FRAME_WIDTH, CHANNELS)
+    # Compute checksum in a streaming fashion
+    sha = hashlib.sha256()
+    with open(input_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            sha.update(chunk)
+    checksum = sha.digest()
+
+    header = (
+        file_size.to_bytes(8, "big")
+        + checksum
+        + b"\x00" * (BYTES_PER_FRAME - 8 - len(checksum))
     )
+    header_frame = _chunk_to_frame(header)
 
-    # Use a lossless codec so encoded videos preserve the exact binary data.
-    # FFV1 is a widely supported lossless codec available in FFMPEG builds
-    # shipped with OpenCV.
-    fourcc = cv2.VideoWriter_fourcc(*"FFV1")
+    # Select codec based on container
+    if container == "mkv":
+        fourcc = cv2.VideoWriter_fourcc(*"FFV1")
+    elif container == "mp4":
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    else:
+        raise ValueError(f"Unsupported container: {container}")
+
     writer = cv2.VideoWriter(
-
         output_path, fourcc, 60, (FRAME_WIDTH, FRAME_HEIGHT)
-
     )
     if not writer.isOpened():
         raise IOError(f"Cannot open video writer for: {output_path}")
 
     writer.write(header_frame)
 
-    with open(input_path, "rb") as f:
+    def pad(chunk: bytes) -> bytes:
+        if len(chunk) < BYTES_PER_FRAME:
+            chunk += b"\x00" * (BYTES_PER_FRAME - len(chunk))
+        return chunk
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as ex, open(
+        input_path, "rb"
+    ) as f:
+        pending = []
         while True:
             chunk = f.read(BYTES_PER_FRAME)
             if not chunk:
                 break
-            if len(chunk) < BYTES_PER_FRAME:
-                chunk += b"\x00" * (BYTES_PER_FRAME - len(chunk))
-            frame = np.frombuffer(chunk, dtype=np.uint8).reshape(
-                (FRAME_HEIGHT, FRAME_WIDTH, CHANNELS)
-            )
-            writer.write(frame)
+            future = ex.submit(_chunk_to_frame, pad(chunk))
+            pending.append(future)
+            if len(pending) >= workers:
+                writer.write(pending.pop(0).result())
+
+        for fut in pending:
+            writer.write(fut.result())
     writer.release()
 
 
-def decode(input_path: str, output_path: str) -> None:
+def decode(
+    input_path: str, output_path: str, *, workers: int = 1
+) -> None:
     """Decode a KFE video back into a binary file."""
     out_dir = os.path.dirname(output_path)
     if out_dir:
@@ -75,22 +131,42 @@ def decode(input_path: str, output_path: str) -> None:
         raise IOError("Input video contains no frames")
     header_bytes = header_frame.tobytes()
     original_size = int.from_bytes(header_bytes[:8], "big")
+    checksum = header_bytes[8 : 8 + hashlib.sha256().digest_size]
 
-    with open(output_path, "wb") as f:
+    sha = hashlib.sha256()
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as ex, open(
+        output_path, "wb"
+    ) as f:
         written = 0
+        pending = []
         while True:
             ret, frame = cap.read()
             if not ret or written >= original_size:
                 break
-            chunk = frame.tobytes()
+            future = ex.submit(_frame_to_bytes, frame)
+            pending.append(future)
+            if len(pending) >= workers:
+                chunk = pending.pop(0).result()
+                bytes_to_write = min(original_size - written, len(chunk))
+                data = chunk[:bytes_to_write]
+                f.write(data)
+                sha.update(data)
+                written += bytes_to_write
+
+        for fut in pending:
+            chunk = fut.result()
+            if written >= original_size:
+                break
             bytes_to_write = min(original_size - written, len(chunk))
-            f.write(chunk[:bytes_to_write])
+            data = chunk[:bytes_to_write]
+            f.write(data)
+            sha.update(data)
             written += bytes_to_write
     cap.release()
 
-    if written != original_size:
+    if written != original_size or sha.digest() != checksum:
         raise IOError(
-            "Video ended before all data could be read; file may be truncated or corrupted"
+            "Video ended before all data could be read or checksum mismatch"
         )
 
 
@@ -101,10 +177,31 @@ def parse_args() -> argparse.Namespace:
     enc = subparsers.add_parser("encode", help="Encode binary to KFE video")
     enc.add_argument("input_file", help="Path to input binary file")
     enc.add_argument("output_file", help="Path to output video file")
+    enc.add_argument(
+        "-c",
+        "--container",
+        choices=["mkv", "mp4"],
+        default="mkv",
+        help="Container format for the output video",
+    )
+    enc.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of worker threads to use during encoding",
+    )
 
     dec = subparsers.add_parser("decode", help="Decode KFE video to binary")
     dec.add_argument("input_file", help="Path to input video file")
     dec.add_argument("output_file", help="Path to output binary file")
+    dec.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of worker threads to use during decoding",
+    )
 
     return parser.parse_args()
 
@@ -112,9 +209,18 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     if args.command == "encode":
-        encode(args.input_file, args.output_file)
+        encode(
+            args.input_file,
+            args.output_file,
+            container=args.container,
+            workers=args.workers,
+        )
     elif args.command == "decode":
-        decode(args.input_file, args.output_file)
+        decode(
+            args.input_file,
+            args.output_file,
+            workers=args.workers,
+        )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kfe-codec"
+version = "0.1.0"
+description = "Prototype KFE codec"
+authors = [{name="KFE Team"}]
+dependencies = ["numpy", "opencv-python"]
+
+[project.scripts]
+kfe-codec = "kfe_codec:main"


### PR DESCRIPTION
## Summary
- add pyproject for package installation and CLI entry point
- support mkv or mp4 output containers and worker threads in CLI
- implement checksum-based validation and threadpool streaming
- document new options and checksum behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b474b155c8325ad8331086a4dc0b1