### PR TITLE
Update setuptools packaging options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,7 @@ dependencies = ["numpy", "opencv-python"]
 
 [project.scripts]
 kfe-codec = "kfe_codec:main"
+
+[tool.setuptools]
+py-modules = ["kfe_codec"]
+packages = []


### PR DESCRIPTION
## Summary
- ensure setuptools treats `kfe_codec.py` as the packaged module
- ignore empty `kfe/` and `codex/` directories as packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b78b6e16c832582e6c37f82854e3a