### PR TITLE
Fix .gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build/
 develop-eggs/
 dist/
 downloads/
-egss/
+eggs/
 .eggs/
 lib/
 lib64/


### PR DESCRIPTION
## Summary
- fix typo in `.gitignore` entry from `egss/` to `eggs/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b7adc206c8325b0e80401f94f6af8