### PR TITLE
Integrate cpECSK encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ kfe_codec.py  # codec implementation
 ## Requirements
 
 - Python 3.8+
-- The Python packages listed in `requirements.txt`
+- The Python packages listed in `requirements.txt` (including `numba` for
+  optimized cpECSK processing)
 
 Install the dependencies with:
 
@@ -49,6 +50,19 @@ Decode a video back to a binary file:
 ```
 kfe-codec decode kfe/output.mkv bin/restored.bin
 ```
+
+### Certificate-based encryption
+
+Optionally provide a certificate file to encrypt frames with **cpECSK**. The
+checksum of the certificate is stored in the video and verified during decoding.
+
+```
+kfe-codec encode bin/input.bin kfe/output --cert cert.bin
+kfe-codec decode kfe/output.mkv bin/restored.bin --cert cert.bin
+```
+
+If the certificate checksum does not match the checksum embedded in the video
+file, decoding aborts with an error.
 
 Add ``--progress`` to either command to display progress information during
 encoding or decoding:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kfe-codec"
 version = "0.1.0"
 description = "Prototype KFE codec"
 authors = [{name="KFE Team"}]
-dependencies = ["numpy", "opencv-python"]
+dependencies = ["numpy", "opencv-python", "numba"]
 
 [project.scripts]
 kfe-codec = "kfe_codec:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 opencv-python
+numba


### PR DESCRIPTION
## Summary
- add cpECSK permutation and VK3 key derivation
- support optional certificate files when encoding/decoding
- verify certificate checksum during decoding
- test certificate-based roundtrip and mismatch detection
- optimize cpECSK permutation with cached indices and numba channel shift

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c00b638b08325a67b723b18f8a38e