### PR TITLE
Add default cert handling for loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ kfe-codec loopback bin/input.bin bin/restored.bin --cert my.cert
 Connect the HDMI output of the capture card to its input and ensure the device
 is accessible via OpenCV. The command sends the encoded video in real-time and
 reconstructs the binary data from the captured frames. If ``--cert`` is not
-provided, ``<video>.cert`` is used if present.
+provided, ``<output>.cert`` is used if present.

--- a/kfe_loopback.py
+++ b/kfe_loopback.py
@@ -39,6 +39,11 @@ def loopback(
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
 
+    if certificate is None:
+        default_cert = output_path + ".cert"
+        if os.path.exists(default_cert):
+            certificate = default_cert
+
     # Pre-compute file size and checksum
     sha = hashlib.sha256()
     file_size = 0

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -67,3 +67,48 @@ def test_loopback_roundtrip(tmp_path):
     )
 
     assert out.read_bytes() == data
+
+
+def test_loopback_with_certificate(tmp_path):
+    device = _FakeDevice()
+    data = os.urandom(BYTES_PER_FRAME + 50)
+    inp = tmp_path / "in.bin"
+    out = tmp_path / "out.bin"
+    cert = tmp_path / "enc.cert"
+
+    inp.write_bytes(data)
+    cert.write_bytes(b"cert-data")
+
+    loopback(
+        str(inp),
+        str(out),
+        certificate=str(cert),
+        writer_factory=device.writer_factory,
+        capture_factory=device.capture_factory,
+    )
+
+    assert out.read_bytes() == data
+    out_cert = tmp_path / "out.bin.cert"
+    assert out_cert.exists()
+    assert out_cert.read_bytes() == b"cert-data"
+
+
+def test_loopback_default_certificate(tmp_path):
+    device = _FakeDevice()
+    data = os.urandom(BYTES_PER_FRAME)
+    inp = tmp_path / "input.bin"
+    out = tmp_path / "output.bin"
+    default_cert = tmp_path / "output.bin.cert"
+
+    inp.write_bytes(data)
+    default_cert.write_bytes(b"default-cert")
+
+    loopback(
+        str(inp),
+        str(out),
+        writer_factory=device.writer_factory,
+        capture_factory=device.capture_factory,
+    )
+
+    assert out.read_bytes() == data
+    assert default_cert.read_bytes() == b"default-cert"


### PR DESCRIPTION
## Summary
- default to using `<output>.cert` in loopback when `--cert` not supplied
- document this behaviour in the README
- expand loopback tests to cover certificate handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c70ee9e7c83259c9bf1614176647b